### PR TITLE
create global wrapper script, refactor install.sh, refactor readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,9 @@ After Installation:
   Installation:
 
   ```sh
-  sudo mkdir /usr/share/BlueToolkit
-  sudo chown $USER:$USER /usr/share/BlueToolkit
-  git clone https://github.com/sgxgsx/BlueToolkit /usr/share/BlueToolkit --recurse-submodules
-  chmod +x /usr/share/BlueToolkit/install.sh
-  /usr/share/BlueToolkit/install.sh
+  git clone https://github.com/sgxgsx/BlueToolkit --recurse-submodules
+  chmod +x ./BlueToolkit/install.sh
+  sudo ./BlueToolkit/install.sh
   ```
 
 </details>

--- a/install.sh
+++ b/install.sh
@@ -1,65 +1,47 @@
 #!/bin/bash
-
+sudo apt-get update
+# Core Python and build essentials
 sudo apt-get install -y python3 python3-dev python3-pip build-essential python3.11-venv python3-venv
+# Bluetooth core dependencies
 sudo apt-get install -y bluez bluetooth libbluetooth-dev
+# PulseAudio Bluetooth module
 sudo apt-get install -y pulseaudio-module-bluetooth
-sudo apt-get install -y zstd unzip
-sudo apt install -y python3-pip python3-dev libcairo2-dev libgirepository1.0-dev \
-                 libbluetooth-dev libdbus-1-dev bluez-tools python3-cairo-dev \
-                 rfkill meson patchelf bluez ubertooth adb python-is-python3
-sudo apt-get install -y git
-sudo apt-get install -y libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
-sudo apt-get install binutils-arm-linux-gnueabi 
-
-# Setting up bluetooth assistant
-sudo apt install -y openjdk-17-jdk openjdk-17-jre
-sudo apt-get install -y android-sdk-platform-tools
-
+# Development, system utilities and Python dependencies
+sudo apt-get install -y zstd unzip git python-is-python3 rfkill meson patchelf ubertooth adb python3-pip python3-dev python3-cairo-dev libcairo2-dev libgirepository1.0-dev libdbus-1-dev bluez-tools
+# System libraries
+sudo apt-get install -y libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev zlib1g-dev libncurses5-dev libnss3-dev libreadline-dev libffi-dev wget
+# ARM and Android tools
+sudo apt-get install -y binutils-arm-linux-gnueabi openjdk-17-jdk openjdk-17-jre android-sdk-platform-tools
 
 # Configure Bluetooth adapter
 sudo killall pulseaudio
 sudo -u vagrant pulseaudio --start
 sudo systemctl restart bluetooth
 
-
 # Creating a base directory and assigning to a current user
 mkdir /usr/share/BlueToolkit
 sudo chown $USER:$USER /usr/share/BlueToolkit
 
-
 # cloning bluekit
 git clone https://github.com/sgxgsx/bluekit.git /usr/share/BlueToolkit/bluekit
-
-
-
 mkdir /usr/share/BlueToolkit/bluekit/.logs 
 mkdir /usr/share/BlueToolkit/modules
 mkdir /usr/share/BlueToolkit/modules/tools -p
 
-
 python3 -m venv /usr/share/BlueToolkit/.venv
 source /usr/share/BlueToolkit/.venv/bin/activate
-#python3 -m pip install -r requirements.txt
-python3 -m pip install pwntools cmd2 pure-python-adb pyelftools==0.29 2to3 scapy psutil tqdm pyyaml #--break-system-packages
+python3 -m pip install pwntools cmd2 pure-python-adb pyelftools==0.29 2to3 scapy psutil tqdm pyyaml setuptools #--break-system-packages
 python3 -m pip install tabulate colorama 
 
 # Install pybluez
 python3 -m pip install git+https://github.com/pybluez/pybluez.git#egg=pybluez #--break-system-packages
 
-
 # installing bluekit
-
 cd /usr/share/BlueToolkit/bluekit/
 pip install .
 
-
-
-
-cd /usr/share/BlueToolkit/modules
-
-
 ## Installing tools in modules
+cd /usr/share/BlueToolkit/modules
 
 #### BluetoothAssistant
 ##### Needs access to the phone, it should be plugged in!!
@@ -78,10 +60,8 @@ make
 cd ..
 
 
-cd /usr/share/BlueToolkit/modules/tools
-
 ## Installing tools in modules/tools
-
+cd /usr/share/BlueToolkit/modules/tools
 
 #### Installing braktooth
 
@@ -96,7 +76,6 @@ unzip esp32driver.zip
 cd ..
 
 #### Cannot install it as there might be no Braktooth connected to the machine
-
 
 #### Installing bluing
 
@@ -135,17 +114,14 @@ sudo python3.10 -m pip install dbus-python==1.2.18
 sudo python3.10 -m pip install --no-dependencies bluing PyGObject docopt btsm btatt bluepy configobj btl2cap pkginfo xpycommon halo pyserial bthci btgatt log_symbols colorama spinners six termcolor
 
 cd ../..
-
 source /usr/share/BlueToolkit/.venv/bin/activate
+
 #### Installing BLUR
-
-
 
 cd /usr/share/BlueToolkit/modules/tools
 git clone https://github.com/francozappa/blur
 
-
-#### Installing blueborne, bleedingteeth, custom_exploits
+#### Installing Internalblue, blueborne, bleedingteeth, custom_exploits
 
 git clone https://github.com/sgxgsx/bluetoothexploits /usr/share/BlueToolkit/modules/tools/blueexploits
 
@@ -160,9 +136,9 @@ gcc -o /usr/share/BlueToolkit/modules/tools/bleedingtooth/poc_badkarma_cve_2020_
 gcc -o /usr/share/BlueToolkit/modules/tools/bleedingtooth/poc_badvibes_cve_2020_24490 /usr/share/BlueToolkit/modules/tools/bleedingtooth/poc_badvibes_cve_2020_24490.c -lbluetooth
 gcc -o /usr/share/BlueToolkit/modules/tools/bleedingtooth/exploit /usr/share/BlueToolkit/modules/tools/bleedingtooth/exploit.c -lbluetooth
 
-cd /usr/share/BlueToolkit/modules/tools/
+#### Internal Blue
 
-#### internalblue 
+cd /usr/share/BlueToolkit/modules/tools/
 git clone https://github.com/seemoo-lab/internalblue /usr/share/BlueToolkit/modules/tools/internalblue
 
 cp /usr/share/BlueToolkit/modules/tools/internalblue/examples/nexus5/CVE_2018_19860_Crash_on_Connect.py /usr/share/BlueToolkit/modules/tools/internalblue/examples/nexus5/CVE_2018_19860_Crash_on_Connect_0a_00.py 
@@ -176,46 +152,20 @@ sed -i 's/LMP_VSC_CMD_END = 0x06/LMP_VSC_CMD_END = 0x0b/' /usr/share/BlueToolkit
 sed -i 's/LMP_VSC_CMD_START = 0x0f/LMP_VSC_CMD_START = 0x20/' /usr/share/BlueToolkit/modules/tools/internalblue/examples/nexus5/CVE_2018_19860_Crash_on_Connect_20_17.py
 sed -i 's/LMP_VSC_CMD_END = 0x06/LMP_VSC_CMD_END = 0x17/' /usr/share/BlueToolkit/modules/tools/internalblue/examples/nexus5/CVE_2018_19860_Crash_on_Connect_20_17.py
 
-cd /usr/share/BlueToolkit/modules/tools/blueborne
-
-git clone https://github.com/sgxgsx/blueborne-CVE-2017-1000251 /usr/share/BlueToolkit/modules/tools/blueborne/blueborne-CVE-2017-1000251
-
-cd /usr/share/BlueToolkit/modules/tools/blueborne/blueborne-CVE-2017-1000251
-
-gcc -o blueborne_cve_2017_1000251 blueborne.c -lbluetooth
-
-
-#### installing Internalblue
-
 python3 -m pip install https://github.com/seemoo-lab/internalblue/archive/master.zip # --break-system-packages
 
+#### Blueborne 
+
+cd /usr/share/BlueToolkit/modules/tools/blueborne
+git clone https://github.com/sgxgsx/blueborne-CVE-2017-1000251 /usr/share/BlueToolkit/modules/tools/blueborne/blueborne-CVE-2017-1000251
+cd /usr/share/BlueToolkit/modules/tools/blueborne/blueborne-CVE-2017-1000251
+gcc -o blueborne_cve_2017_1000251 blueborne.c -lbluetooth
 export PYTHONPATH=$PYTHONPATH:$(pwd)/tools/blueborne
 
-sudo chown -R $USER:$USER /usr/share/BlueToolkit
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# create wrapper script
+cat > /usr/local/bin/bluekit << 'EOF'
+#!/bin/bash
+source /usr/share/BlueToolkit/.venv/bin/activate
+bluekit "$@"
+EOF
+sudo chmod +x /usr/local/bin/bluekit


### PR DESCRIPTION
resolHello!

I made the following changes:

I added the creation of a wrapper script which installs to `/usr/local/bin` - This wrapper script allows users to easily run `sudo bluekit` to run bluekit outside of sourcing the venv. This works for me and tested on fresh Debian12 container. I also updated the README.md to reflect this. Will also need to update the -h output and readme.md/wiki with this change if accepted. this resolves #15


I refactored the APT dependency installs to be more readable and grouped logically. No packages were added or removed.  I tested this in a fresh Debian12 container and it behaved as expected. I added an apt-get update to ensure package lists are up to date on fresh systems/containers.

I refactored the install instructions to remove cloning to /usr/share/ because this requires sudo (as it is a protected folder) and isn't required for bluekit to install. So we can clone to the current directory, let me know if this is OK. I also updated the README.md to reflect this.

In my testing ./install.sh requires sudo to run, so I added `sudo` to the install instructions for ./install.sh

I added `setuptools` to the pip installs as it was reported as a dependency needed in some contexts (Kali). resolves #10 

removed this from the install instructions as it is done by install.sh:

sudo mkdir /usr/share/BlueToolkit
sudo chown $USER:$USER /usr/share/BlueToolkit

I made some minor modifications to the syntax and placement of some commands to be more readable with their parent comments.

Let me know your thoughts!